### PR TITLE
Update Time Series Forecastings.ipynb

### DIFF
--- a/Time Series Forecastings.ipynb
+++ b/Time Series Forecastings.ipynb
@@ -1067,7 +1067,7 @@
     }
    ],
    "source": [
-    "first_date = store.ix[np.min(list(np.where(store['office_sales'] > store['furniture_sales'])[0])), 'Order Date']\n",
+    "first_date = store.loc[np.min(list(np.where(store['office_sales'] > store['furniture_sales'])[0])), 'Order Date']\n",
     "\n",
     "print(\"Office supplies first time produced higher sales than furniture is {}.\".format(first_date.date()))"
    ]


### PR DESCRIPTION
when checking Office supplies first time producing higher sales than furniture the .ix is deprecated hence first_date = store.ix[...] should be changed to first_date = store.loc[....] Thanks